### PR TITLE
Fix AttributeError: 'list' object has no attribute 'size' in SPN pipeline

### DIFF
--- a/fix_tests.py
+++ b/fix_tests.py
@@ -1,0 +1,26 @@
+import re
+
+with open("tests/test_SPN.py", "r") as f:
+    content = f.read()
+
+# Replace list definitions with np.array
+content = re.sub(r'vertices = \[np\.array\(\[.*?\]\)(?:, np\.array\(\[.*?\]\))*\]',
+                 lambda m: "vertices = np.array(" + m.group(0)[11:] + ")", content)
+
+content = content.replace("edges = [[0, 1]]", "edges = np.array([[0, 1]])")
+content = content.replace("edges = [[0, 1], [1, 0]]", "edges = np.array([[0, 1], [1, 0]])")
+content = content.replace("edges = [[0, 1], [1, 2]]", "edges = np.array([[0, 1], [1, 2]])")
+content = content.replace("edges = [[0, 1], [1, 0], [2, 2]]", "edges = np.array([[0, 1], [1, 0], [2, 2]])")
+
+content = content.replace("arc_transitions = [0]", "arc_transitions = np.array([0])")
+content = content.replace("lambda_values = [2.0]", "lambda_values = np.array([2.0])")
+content = content.replace("edges = []", "edges = np.empty((0, 2), dtype=int)")
+
+# Fix vertices lines specifically since regex might be hard
+content = content.replace("vertices = [np.array([1, 0]), np.array([0, 1])]", "vertices = np.array([[1, 0], [0, 1]])")
+content = content.replace("vertices = [np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]", "vertices = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])")
+content = content.replace("vertices = [np.array([2, 0]), np.array([0, 2])]", "vertices = np.array([[2, 0], [0, 2]])")
+content = content.replace("vertices = [np.array([1])]", "vertices = np.array([[1]])")
+
+with open("tests/test_SPN.py", "w") as f:
+    f.write(content)

--- a/src/spn_datasets/generator/ArrivableGraph.py
+++ b/src/spn_datasets/generator/ArrivableGraph.py
@@ -191,9 +191,9 @@ def generate_reachability_graph(incidence_matrix_with_initial, place_upper_limit
 
     Returns:
         tuple: A tuple containing:
-            - list: The list of unique reachable markings (states).
-            - list: List of edges [from_marking_idx, to_marking_idx].
-            - list: List of transition indices corresponding to each edge.
+            - numpy.ndarray: The unique reachable markings (states).
+            - numpy.ndarray: Edges as [from_marking_idx, to_marking_idx].
+            - numpy.ndarray: Transition indices corresponding to each edge.
             - int: Number of transitions in the Petri net.
             - bool: Boolean indicating if the net is bounded.
     """
@@ -212,18 +212,12 @@ def generate_reachability_graph(incidence_matrix_with_initial, place_upper_limit
         max_markings_to_explore,
     )
 
-    # Convert Numba arrays to Python lists for compatibility
-    # ⚡ Bolt Optimization: Use pure NumPy vectorized methods to unbox arrays
-    # into Python lists. `np.column_stack` combined with `.tolist()` runs up
-    # to 5x faster than list comprehensions over large flat arrays.
-    py_visited_markings_list = list(visited_markings_list)
-    py_reachability_edges = np.column_stack((reach_src, reach_dst)).tolist()
-    py_edge_transition_indices = edge_transition_indices.tolist()
+    reachability_edges = np.column_stack((reach_src, reach_dst))
 
     return (
-        py_visited_markings_list,
-        py_reachability_edges,
-        py_edge_transition_indices,
+        visited_markings_list,
+        reachability_edges,
+        edge_transition_indices,
         num_transitions,
         is_bounded,
     )

--- a/src/spn_datasets/generator/DataTransformation.py
+++ b/src/spn_datasets/generator/DataTransformation.py
@@ -76,9 +76,9 @@ def _generate_rate_variations(base_variation, num_variations):
     for _ in range(num_variations):
         new_rates = np.random.randint(1, 11, size=num_trans).astype(float)
         s_probs, m_dens, avg_marks, success = SPN.generate_stochastic_net_task_with_rates(
-            [v for v in base_variation["arr_vlist"]],
-            base_variation["arr_edge"].tolist(),
-            base_variation["arr_tranidx"].tolist(),
+            np.array(base_variation["arr_vlist"]),
+            np.array(base_variation["arr_edge"]),
+            np.array(base_variation["arr_tranidx"]),
             new_rates,
         )
 

--- a/src/spn_datasets/generator/SPN.py
+++ b/src/spn_datasets/generator/SPN.py
@@ -218,6 +218,9 @@ def generate_stochastic_net_task(
         A tuple with steady-state probabilities, mark density, average markings,
         firing rates, and a success flag.
     """
+    vertices = np.array(vertices)
+    edges = np.array(edges)
+    arc_transitions = np.array(arc_transitions)
     transition_rates = np.random.randint(1, 11, size=num_transitions).astype(float)
     probs, density, markings, success = _run_sgn_task(vertices, edges, arc_transitions, transition_rates)
     return probs, density, markings, transition_rates, success
@@ -230,6 +233,10 @@ def generate_stochastic_net_task_with_rates(
     transition_rates: np.ndarray,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, bool]:
     """Generates an SGN task with specified firing rates."""
+    vertices = np.array(vertices)
+    edges = np.array(edges)
+    arc_transitions = np.array(arc_transitions)
+    transition_rates = np.array(transition_rates)
     return _run_sgn_task(vertices, edges, arc_transitions, transition_rates.astype(float))
 
 
@@ -478,6 +485,10 @@ def get_spn_info(
 ) -> Tuple[Dict[str, Any], bool]:
     """Retrieves SPN info for a given structure and rates."""
     petri_net_matrix = np.array(petri_net_matrix)  # Ensure it's a numpy array
+    vertices = np.array(vertices)
+    edges = np.array(edges)
+    arc_transitions = np.array(arc_transitions)
+    transition_rates = np.array(transition_rates)
     if not is_connected(petri_net_matrix) or vertices.size == 0:
         return {}, False
 

--- a/tests/test_ArrivableGraph.py
+++ b/tests/test_ArrivableGraph.py
@@ -50,8 +50,8 @@ def test_generate_reachability_graph(simple_petri_net):
     assert len(t) == 1
     assert np.allclose(v[0], np.array([1, 0]))
     assert np.allclose(v[1], np.array([0, 1]))
-    assert e[0] == [0, 1]
-    assert t[0] == 0
+    assert e.tolist()[0] == [0, 1]
+    assert t.tolist()[0] == 0
 
 
 def test_generate_reachability_graph_unbounded():
@@ -96,4 +96,4 @@ def test_generate_reachability_graph_revisited_marking():
     assert len(v) == 2
     assert len(e) == 2
     assert len(t) == 2
-    assert e[1] == [1, 0]  # Should be a back edge
+    assert e.tolist()[1] == [1, 0]  # Should be a back edge

--- a/tests/test_SPN.py
+++ b/tests/test_SPN.py
@@ -52,9 +52,9 @@ def test_is_connected_single_place_no_transitions():
 
 def test_compute_state_equation():
     """Test the computation of the state equation."""
-    vertices = [np.array([1, 0]), np.array([0, 1])]
-    edges = [[0, 1]]
-    arc_transitions = [0]
+    vertices = np.array([np.array([1, 0]), np.array([0, 1])])
+    edges = np.array([[0, 1]])
+    arc_transitions = np.array([0])
     lambda_values = np.array([2.0])
     state_matrix, target_vector = compute_state_equation(vertices, edges, arc_transitions, lambda_values)
 
@@ -98,9 +98,9 @@ def test_compute_average_markings():
 
 def test_generate_stochastic_net_task():
     """Test the generation of a stochastic net task."""
-    vertices = [np.array([1, 0]), np.array([0, 1])]
-    edges = [[0, 1]]
-    arc_transitions = [0]
+    vertices = np.array([np.array([1, 0]), np.array([0, 1])])
+    edges = np.array([[0, 1]])
+    arc_transitions = np.array([0])
     num_transitions = 1
     _, _, markings, _, success = generate_stochastic_net_task(vertices, edges, arc_transitions, num_transitions)
     assert success is True
@@ -140,8 +140,8 @@ def test_compute_state_equation_numba():
 
 def test_compute_qualitative_properties_simple_cycle():
     """Test qualitative properties on a simple cycle 0 <-> 1."""
-    vertices = [np.array([1, 0]), np.array([0, 1])]
-    edges = [[0, 1], [1, 0]]
+    vertices = np.array([np.array([1, 0]), np.array([0, 1])])
+    edges = np.array([[0, 1], [1, 0]])
     props = compute_qualitative_properties(vertices, edges)
 
     assert props["is_deadlock_free"] is True
@@ -152,8 +152,8 @@ def test_compute_qualitative_properties_simple_cycle():
 
 def test_compute_qualitative_properties_deadlock():
     """Test qualitative properties with a deadlock 0 -> 1 -> 2 (stuck)."""
-    vertices = [np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]
-    edges = [[0, 1], [1, 2]]
+    vertices = np.array([np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])])
+    edges = np.array([[0, 1], [1, 2]])
     props = compute_qualitative_properties(vertices, edges)
 
     assert props["is_deadlock_free"] is False
@@ -163,8 +163,8 @@ def test_compute_qualitative_properties_deadlock():
 
 def test_compute_qualitative_properties_unsafe():
     """Test qualitative properties with unsafe marking."""
-    vertices = [np.array([1, 0]), np.array([0, 2])]
-    edges = [[0, 1], [1, 0]]
+    vertices = np.array([np.array([1, 0]), np.array([0, 2])])
+    edges = np.array([[0, 1], [1, 0]])
     props = compute_qualitative_properties(vertices, edges)
 
     assert props["is_safe"] is False
@@ -173,8 +173,8 @@ def test_compute_qualitative_properties_unsafe():
 
 def test_compute_qualitative_properties_no_edges():
     """Test qualitative properties with no edges (single state)."""
-    vertices = [np.array([1])]
-    edges = []
+    vertices = np.array([np.array([1])])
+    edges = np.empty((0, 2), dtype=int)
     props = compute_qualitative_properties(vertices, edges)
 
     # If only one state and no transitions, it's effectively a deadlock
@@ -189,8 +189,8 @@ def test_compute_qualitative_properties_disconnected_reachability():
     """Test reversibility with disconnected components (impossible in reachability from M0, but testing graph logic)."""
     # 0 -> 1, 2 (2 is unreachable from 0, but passed in vertices list)
     # This simulates a graph where not all nodes can reach back to 0.
-    vertices = [np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])]
-    edges = [[0, 1], [1, 0], [2, 2]]
+    vertices = np.array([np.array([1, 0, 0]), np.array([0, 1, 0]), np.array([0, 0, 1])])
+    edges = np.array([[0, 1], [1, 0], [2, 2]])
 
     # In a real reachability graph generated from M0 (0), 2 wouldn't be there.
     # But if we pass it manually:

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -130,8 +130,8 @@ def test_benchmark_is_connected(benchmark):
 
 
 def test_benchmark_compute_qualitative_properties(benchmark):
-    vertices = [np.random.randint(0, 5, size=(50,)).astype(np.int32) for _ in range(500)]
-    edges = [[i, (i + 1) % 500] for i in range(500)]
+    vertices = np.array([np.random.randint(0, 5, size=(50,)).astype(np.int32) for _ in range(500)])
+    edges = np.array([[i, (i + 1) % 500] for i in range(500)])
 
     def f():
         compute_qualitative_properties(vertices, edges)


### PR DESCRIPTION
The bug was caused by `generate_reachability_graph` returning Python `list` instead of `numpy.ndarray` for `vertices` and `edges`, causing `vertices.size` in `SPN.py` to throw an `AttributeError`.

This PR:
- Avoids unboxing internal arrays into Python lists in `ArrivableGraph.py`.
- Defensively converts list inputs to numpy arrays in `SPN.py` endpoints that use `.size` or `.astype`.
- Updates `DataTransformation.py` to stop using `.tolist()`.
- Fixes unit and integration tests failing due to these array type mismatches.

---
*PR created automatically by Jules for task [17257213715114880926](https://jules.google.com/task/17257213715114880926) started by @CombatOrpheus*