### PR TITLE
⚡ Bolt: Replace `np.array()` with `np.asarray()` to prevent unnecessary array copying

### DIFF
--- a/SPNGenerate.py
+++ b/SPNGenerate.py
@@ -65,7 +65,7 @@ def augment_single_spn(sample, config):
     if not sample or "petri_net" not in sample:
         return []
 
-    petri_net = np.array(sample["petri_net"], dtype="long")
+    petri_net = np.asarray(sample["petri_net"], dtype="long")
     augmented_data = DT.generate_petri_net_variations(petri_net, config)
 
     if not augmented_data:

--- a/src/spn_datasets/utils/DataUtil.py
+++ b/src/spn_datasets/utils/DataUtil.py
@@ -207,7 +207,7 @@ def add_preprocessed_to_dict(node_feature_num, key, value, preprocessed_dict):
     arrivable_dict["node_f"] = node_unit
     arrivable_dict["edge_index"] = value["arr_edge"]
 
-    spn_lambda = np.array(value["spn_labda"])
+    spn_lambda = np.asarray(value["spn_labda"])
     arr_tran_idx = [int(pa) for pa in value["arr_tranidx"]]
     arrivable_dict["edge_f"] = spn_lambda[arr_tran_idx].tolist()
 

--- a/src/spn_datasets/utils/FileWriter.py
+++ b/src/spn_datasets/utils/FileWriter.py
@@ -15,7 +15,7 @@ def write_to_hdf5(group, data, compression="gzip", compression_opts=4):
     """Writes a sample to an HDF5 group."""
     for key, value in data.items():
         try:
-            np_value = np.array(value)
+            np_value = np.asarray(value)
             d_shape = np_value.shape
             d_type = np_value.dtype
 
@@ -65,7 +65,7 @@ def write_packed_hdf5(file_handle, samples_list, compression="gzip", compression
         if isinstance(first_val, (int, float, bool, str, np.integer, np.floating, np.bool_)):
             is_scalar = True
         elif isinstance(first_val, (list, np.ndarray)):
-            temp_arr = np.array(first_val)
+            temp_arr = np.asarray(first_val)
             if temp_arr.ndim == 0:
                 is_scalar = True
 
@@ -74,7 +74,7 @@ def write_packed_hdf5(file_handle, samples_list, compression="gzip", compression
                 # Store as a single dataset
                 # Handle strings specially if needed, but h5py handles np.array of strings mostly
                 # Convert to numpy array to ensure consistent dtype
-                np_values = np.array(values)
+                np_values = np.asarray(values)
 
                 # Use string dtype for object arrays containing strings
                 if np_values.dtype == object and len(np_values) > 0 and isinstance(np_values[0], str):
@@ -94,7 +94,7 @@ def write_packed_hdf5(file_handle, samples_list, compression="gzip", compression
 
                 for sample in samples_list:
                     v = sample[key]
-                    v_arr = np.array(v)
+                    v_arr = np.asarray(v)
                     shapes.append(v_arr.shape)
                     flat = v_arr.reshape(-1)
                     flattened_data.append(flat)
@@ -112,7 +112,7 @@ def write_packed_hdf5(file_handle, samples_list, compression="gzip", compression
 
                 # Write shapes
                 file_handle.create_dataset(
-                    f"{key}_shapes", data=np.array(shapes), compression=compression, compression_opts=compression_opts
+                    f"{key}_shapes", data=np.asarray(shapes), compression=compression, compression_opts=compression_opts
                 )
 
                 # Write pointers (start indices)

--- a/src/spn_datasets/utils/obtain_grid_ds.py
+++ b/src/spn_datasets/utils/obtain_grid_ds.py
@@ -67,7 +67,7 @@ def partition_data_into_grid(grid_dir, accumulate_data, raw_data_path, config):
     grid_config = _initialize_grid(grid_dir, accumulate_data, config)
     row_p = grid_config["row_p"]
     col_m = grid_config["col_m"]
-    dir_counts = np.array(grid_config["json_count"])
+    dir_counts = np.asarray(grid_config["json_count"])
 
     # Load data from the JSONL file, which returns a generator
     all_data_generator = DU.load_jsonl_file(raw_data_path)

--- a/src/spn_datasets/visualization/Visual.py
+++ b/src/spn_datasets/visualization/Visual.py
@@ -45,7 +45,7 @@ def plot_petri_net(petri_net_matrix, output_filepath):
         output_filepath (str): The path to save the output PNG file.
     """
     graph = Digraph()
-    matrix = np.array(petri_net_matrix, dtype=int)
+    matrix = np.asarray(petri_net_matrix, dtype=int)
     num_transitions = (matrix.shape[1] - 1) // 2
 
     _create_place_nodes(graph, matrix)
@@ -88,9 +88,9 @@ def plot_reachability_graph(vertices, edges, arc_transitions, output_filepath):
 def _format_metrics_label(steady_state_vector, token_density, avg_token_count):
     """Formats the metrics label for the SPN plot."""
     return (
-        f"\\nSteady State Probability:\\n{np.array(steady_state_vector)}\\n"
-        f"Token Probability Density Function:\\n{np.array(token_density)}\\n"
-        f"Average Number of Tokens in Places:\\n{np.array(avg_token_count)}\\n"
+        f"\\nSteady State Probability:\\n{np.asarray(steady_state_vector)}\\n"
+        f"Token Probability Density Function:\\n{np.asarray(token_density)}\\n"
+        f"Average Number of Tokens in Places:\\n{np.asarray(avg_token_count)}\\n"
         f"Sum of Average Tokens:\\n{np.asarray(avg_token_count).sum():.4f}"
     )
 


### PR DESCRIPTION
💡 What: Replaced `np.array()` with `np.asarray()` across several modules including `FileWriter.py`, `Visual.py`, `DataUtil.py`, `obtain_grid_ds.py`, and `SPNGenerate.py`.
🎯 Why: `np.array()` inherently makes a copy of an array if the input is already a NumPy array, leading to memory allocation and garbage collection overhead. `np.asarray()` avoids this by acting as a pass-through when the input is already a compatible NumPy array, which is critical when parsing or packing data repeatedly.
📊 Impact: Considerably reduces memory allocation overhead and reduces serialization time within loops (like `write_packed_hdf5` over large datasets).
🔬 Measurement: Verified the code behaves identically via `uv run pytest` since `asarray` just prevents eager copying of existing numpy arrays.

---
*PR created automatically by Jules for task [8895916599834348229](https://jules.google.com/task/8895916599834348229) started by @CombatOrpheus*