### PR TITLE
⚡ Bolt: Cache markings.sum() in filter_spn

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -24,3 +24,7 @@
 ## 2024-04-25 - [Numba Type Mismatch Recompilation]
 **Learning:** If a Numba JIT function (`@numba.jit(cache=True)`) is repeatedly called with numpy arrays of varying types (e.g. `np.int64` vs `np.int32` depending on the platform or generation method), Numba will spend significant time recompiling the function for the new signature during runtime.
 **Action:** To prevent Numba recompilation overhead on every unique array type signature (especially during batch generation), ensure inputs like `vertices`, `edges`, and `arc_transitions` are explicitly and consistently typed (e.g., using `np.asarray(..., dtype=np.int32)` or `np.float64`) before being passed to `@numba.jit` functions.
+
+## 2024-04-28 - [Cache Array Reductions]
+**Learning:** Calling `.sum()` or other reduction methods on NumPy arrays multiple times in short succession (e.g., in a chained `if` statement like `if markings.sum() > 1000 or markings.sum() < -1000:`) evaluates the entire array repeatedly, causing unnecessary performance overhead.
+**Action:** Always cache the result of array reduction methods in a variable (e.g., `markings_sum = markings.sum()`) when using it multiple times in the same code block to avoid redundant evaluations.

--- a/src/spn_datasets/generator/SPN.py
+++ b/src/spn_datasets/generator/SPN.py
@@ -528,7 +528,13 @@ def filter_spn(
         success,
     ) = generate_stochastic_net_task(vertices, edges, arc_transitions, num_transitions)
 
-    if not success or markings.sum() > 1000 or markings.sum() < -1000:
+    if not success:
+        return {}, False
+
+    # ⚡ Bolt Optimization: Cache markings.sum() to a variable
+    # to avoid evaluating `.sum()` twice on the NumPy array.
+    markings_sum = markings.sum()
+    if markings_sum > 1000 or markings_sum < -1000:
         return {}, False
 
     return (


### PR DESCRIPTION
💡 What: Cached the result of `markings.sum()` in `filter_spn`.
🎯 Why: Previously, the code evaluated `markings.sum() > 1000 or markings.sum() < -1000:`, meaning it was unnecessarily calculating the sum of the array twice. By assigning it to `markings_sum`, it eliminates the duplicate computation.
📊 Impact: Halves the execution time of checking the markings sum bounds, leading to roughly a 2x speedup in that specific block according to local benchmark tests.
🔬 Measurement: Verified the improvement locally with `benchmark_sum.py`. Run tests using `uv run pytest` to guarantee no logic breaking.

---
*PR created automatically by Jules for task [6384613186969509196](https://jules.google.com/task/6384613186969509196) started by @CombatOrpheus*